### PR TITLE
Support multi-lines message

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/lib/ruboty/echo.rb
+++ b/lib/ruboty/echo.rb
@@ -5,7 +5,7 @@ module Ruboty
   module Handlers
     class Echo < Base
       on(
-        /echo\s+(.*)/,
+        /echo\s+(.*)/m,
         name: 'echo',
         description: 'repeat your commnad'
       )

--- a/ruboty-echo.gemspec
+++ b/ruboty-echo.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ruboty"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec", "3.2.0"
   spec.add_development_dependency "pry"
 end

--- a/spec/ruboty/handlers/echo_spec.rb
+++ b/spec/ruboty/handlers/echo_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Ruboty::Handlers::Echo do
+  let(:robot) do
+    Ruboty::Robot.new
+  end
+
+  describe '#echo' do
+    shared_examples 'echoes given message' do
+      it 'echoes given message' do
+        expect(robot).to receive(:say).with(
+          hash_including(
+            body: given_message,
+          ),
+        )
+        robot.receive(body: "#{robot.name} echo #{given_message}")
+      end
+    end
+
+    context 'without line break' do
+      let(:given_message) do
+        'test'
+      end
+
+      include_examples 'echoes given message'
+    end
+
+    context 'with line break' do
+      let(:given_message) do
+        "test\ntest"
+      end
+
+      include_examples 'echoes given message'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+require 'ruboty/echo'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.disable_monkey_patching!
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+  config.warnings = true
+end


### PR DESCRIPTION
https://github.com/r7kamura/ruboty-cron/pull/3 の調査でデバッグしようとしてて、改行を含んだメッセージをRubotyに発言してみてもらいたかったんですが、現行のruboty-echoではサポートされてなかったので mオプション (Regexp::MULTILINE) を追加してみました。
